### PR TITLE
Do not require @types/node

### DIFF
--- a/packages/context/package-lock.json
+++ b/packages/context/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@wry/context",
-  "version": "0.1.5",
+  "version": "0.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/context/package.json
+++ b/packages/context/package.json
@@ -17,13 +17,18 @@
     "url": "https://github.com/benjamn/wryware/issues"
   },
   "scripts": {
-    "clean": "../../node_modules/.bin/rimraf lib",
     "tsc": "../../node_modules/.bin/tsc",
     "rollup": "../../node_modules/.bin/rollup -c",
-    "build": "npm run clean && npm run tsc && npm run rollup",
+    "clean": "../../node_modules/.bin/rimraf lib",
+    "build": "npm run tsc",
+    "build:test": "npm run tsc -- --project ./tsconfig.test.json",
+    "prebuild": "npm run clean",
+    "postbuild": "npm run rollup",
+    "prebuild:test": "npm run prebuild",
+    "postbuild:test": "npm run postbuild",
     "mocha": "../../scripts/test.sh lib/tests.js",
     "prepublish": "npm run build",
-    "test": "npm run build && npm run mocha"
+    "test": "npm run build:test && npm run mocha"
   },
   "dependencies": {
     "tslib": "^1.9.3"

--- a/packages/context/tsconfig.rollup.json
+++ b/packages/context/tsconfig.rollup.json
@@ -3,4 +3,5 @@
   "compilerOptions": {
     "module": "es2015",
   },
+  "exclude": ["./src/tests.ts"]
 }

--- a/packages/context/tsconfig.test.json
+++ b/packages/context/tsconfig.test.json
@@ -1,8 +1,7 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "../../tsconfig.test.json",
   "compilerOptions": {
     "rootDir": "./src",
     "outDir": "./lib"
-  },
-  "exclude": ["./src/tests.ts"]
+  }
 }

--- a/packages/task/package-lock.json
+++ b/packages/task/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@wry/task",
-  "version": "0.1.6",
+  "version": "0.1.14",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -8,6 +8,12 @@
       "version": "file:../context",
       "requires": {
         "tslib": "^1.9.3"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.9.3",
+          "bundled": true
+        }
       }
     },
     "tslib": {

--- a/packages/task/package.json
+++ b/packages/task/package.json
@@ -23,13 +23,18 @@
     "url": "https://github.com/benjamn/wryware/issues"
   },
   "scripts": {
-    "clean": "../../node_modules/.bin/rimraf lib",
     "tsc": "../../node_modules/.bin/tsc",
+    "clean": "../../node_modules/.bin/rimraf lib",
     "rollup": "../../node_modules/.bin/rollup -c",
-    "build": "npm run clean && npm run tsc && npm run rollup",
+    "build": "npm run tsc",
+    "build:test": "npm run tsc -- --project ./tsconfig.test.json",
+    "prebuild": "npm run clean",
+    "postbuild": "npm run rollup",
+    "prebuild:test": "npm run prebuild",
+    "postbuild:test": "npm run postbuild",
     "mocha": "../../scripts/test.sh lib/tests.js",
     "prepublish": "npm run build",
-    "test": "npm run build && npm run mocha"
+    "test": "npm run build:test && npm run mocha"
   },
   "dependencies": {
     "@wry/context": "file:../context",

--- a/packages/task/tsconfig.json
+++ b/packages/task/tsconfig.json
@@ -3,5 +3,6 @@
   "compilerOptions": {
     "rootDir": "./src",
     "outDir": "./lib"
-  }
+  },
+  "exclude": ["./src/tests.ts"]
 }

--- a/packages/task/tsconfig.rollup.json
+++ b/packages/task/tsconfig.rollup.json
@@ -3,4 +3,5 @@
   "compilerOptions": {
     "module": "es2015",
   },
+  "exclude": ["./src/tests.ts"]
 }

--- a/packages/task/tsconfig.test.json
+++ b/packages/task/tsconfig.test.json
@@ -1,8 +1,7 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "../../tsconfig.test.json",
   "compilerOptions": {
     "rootDir": "./src",
     "outDir": "./lib"
-  },
-  "exclude": ["./src/tests.ts"]
+  }
 }

--- a/packages/template/package.json
+++ b/packages/template/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@wry/template",
+  "version": "0.0.0",
   "private": true,
   "author": "Ben Newman <ben@eloper.dev>",
   "description": "Template for new @wry/* packages",
@@ -17,13 +18,18 @@
     "url": "https://github.com/benjamn/wryware/issues"
   },
   "scripts": {
-    "clean": "../../node_modules/.bin/rimraf lib",
     "tsc": "../../node_modules/.bin/tsc",
+    "clean": "../../node_modules/.bin/rimraf lib",
     "rollup": "../../node_modules/.bin/rollup -c",
-    "build": "npm run clean && npm run tsc && npm run rollup",
+    "build": "npm run tsc",
+    "build:test": "npm run tsc -- --project ./tsconfig.test.json",
+    "prebuild": "npm run clean",
+    "postbuild": "npm run rollup",
+    "prebuild:test": "npm run prebuild",
+    "postbuild:test": "npm run postbuild",
     "mocha": "../../scripts/test.sh lib/tests.js",
     "prepublish": "npm run build",
-    "test": "npm run build && npm run mocha"
+    "test": "npm run build:test && npm run mocha"
   },
   "dependencies": {
     "tslib": "^1.9.3"

--- a/packages/template/tsconfig.json
+++ b/packages/template/tsconfig.json
@@ -2,6 +2,8 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "rootDir": "./src",
-    "outDir": "./lib"
-  }
+    "outDir": "./lib",
+    "types": ["node"]
+  },
+  "exclude": ["./src/tests.ts"]
 }

--- a/packages/template/tsconfig.rollup.json
+++ b/packages/template/tsconfig.rollup.json
@@ -3,4 +3,5 @@
   "compilerOptions": {
     "module": "es2015",
   },
+  "exclude": ["./src/tests.ts"]
 }

--- a/packages/template/tsconfig.test.json
+++ b/packages/template/tsconfig.test.json
@@ -1,8 +1,7 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "../../tsconfig.test.json",
   "compilerOptions": {
     "rootDir": "./src",
     "outDir": "./lib"
-  },
-  "exclude": ["./src/tests.ts"]
+  }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,8 +5,8 @@
     "importHelpers": true,
     "declaration": true,
     "sourceMap": true,
-    "lib": ["es2015"],
-    "types": ["node", "mocha"],
+    "lib": ["es2015", "dom"],
+    "types": [],
     "strict": true,
     "noImplicitAny": true,
     "esModuleInterop": true

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "types": ["node", "mocha"]
+  }
+}


### PR DESCRIPTION
@benjamn let me know if you want to stay with npm or switch to yarn and its Workspaces. I see Yarn a bit better to work with when it comes to executables in monorepos.

What I did:
- Excluded `src/tests.ts` from the distributed files
- Prepared a tsconfig for tests (includes `src/tests.ts`)
- Implemented a new script `build:test` that reuses `tsc` but with one additional argument.
- Turned `clean` and `rollup` into `pre/post` hooks so we could share it with `build:test`.

Fixes #4
Fixes https://github.com/apollographql/apollo-angular/issues/1200