### PR TITLE
Make generated types compatible with node >=6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -849,9 +849,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "12.0.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.0.2.tgz",
-      "integrity": "sha512-5tabW/i+9mhrfEOUcLDu2xBPsHJ+X5Orqy9FKpale3SjDA17j5AEpYq5vfy3oAeAHGcvANRCO3NV3d2D6q3NiA==",
+      "version": "6.14.6",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-6.14.6.tgz",
+      "integrity": "sha512-rFs9zCFtSHuseiNXxYxFlun8ibu+jtZPgRM+2ILCmeLiGeGLiIGxuOzD+cNyHegI1GD+da3R/cIbs9+xCLp13w==",
       "dev": true
     },
     "JSONStream": {
@@ -5192,6 +5192,14 @@
         "@types/estree": "0.0.39",
         "@types/node": "^12.0.2",
         "acorn": "^6.1.1"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "12.0.4",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.0.4.tgz",
+          "integrity": "sha512-j8YL2C0fXq7IONwl/Ud5Kt0PeXw22zGERt+HSSnwbKOJVsAGkEz3sFCYwaF9IOuoG1HOtE0vKCj6sXF7Q0+Vaw==",
+          "dev": true
+        }
       }
     },
     "rollup-plugin-typescript2": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "devDependencies": {
     "@types/mocha": "^5.2.6",
-    "@types/node": "^12.0.2",
+    "@types/node": ">=6",
     "lerna": "^3.13.1",
     "mocha": "^6.0.2",
     "rimraf": "^2.6.3",

--- a/packages/context/package-lock.json
+++ b/packages/context/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "@wry/context",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@types/node": {
-      "version": "12.0.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.0.2.tgz",
-      "integrity": "sha512-5tabW/i+9mhrfEOUcLDu2xBPsHJ+X5Orqy9FKpale3SjDA17j5AEpYq5vfy3oAeAHGcvANRCO3NV3d2D6q3NiA=="
+      "version": "6.14.6",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-6.14.6.tgz",
+      "integrity": "sha512-rFs9zCFtSHuseiNXxYxFlun8ibu+jtZPgRM+2ILCmeLiGeGLiIGxuOzD+cNyHegI1GD+da3R/cIbs9+xCLp13w=="
     },
     "tslib": {
       "version": "1.9.3",

--- a/packages/context/package.json
+++ b/packages/context/package.json
@@ -26,7 +26,7 @@
     "test": "npm run build && npm run mocha"
   },
   "dependencies": {
-    "@types/node": "^12.0.2",
+    "@types/node": ">=6",
     "tslib": "^1.9.3"
   }
 }

--- a/packages/task/package-lock.json
+++ b/packages/task/package-lock.json
@@ -1,14 +1,24 @@
 {
   "name": "@wry/task",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@wry/context": {
       "version": "file:../context",
       "requires": {
-        "@types/node": "^12.0.2",
+        "@types/node": ">=6",
         "tslib": "^1.9.3"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "6.14.6",
+          "bundled": true
+        },
+        "tslib": {
+          "version": "1.9.3",
+          "bundled": true
+        }
       }
     },
     "tslib": {


### PR DESCRIPTION
I have a project that is using wry/context (indirectly) and my project is compiling with a dependency of @types/node = ^8 since that's the runtime I'm targeting. When I try to compile, I get the following error:

```
node_modules/@wry/context/lib/context.d.ts:6:84 - error TS2694: Namespace 'NodeJS' has no exported member 'Timeout'.

6 declare function setTimeoutWithContext(callback: () => any, delay: number): NodeJS.Timeout;
```

Because wry/context is depending on node 12, newer types are being included in the lib/context.d.ts file than exist in node 8. If your dependencies are changed to include all of the runtime version that you support, then the code generated by lib/context.d.ts is different and compatible with older versions of node too.

P.S. I used node 6 as the start of the range to match the .travis.yml testing range, but I'm equally happy to change it to >= 8 to match the supported node versions

Fixes #4 