### PR TITLE
don't pull @node/types into global namespace

### DIFF
--- a/packages/context/src/context.ts
+++ b/packages/context/src/context.ts
@@ -2,6 +2,8 @@ import { Slot } from "./slot";
 export { Slot }
 export const { bind, noContext } = Slot;
 
+declare function setTimeout(callback: (...args: any[]) => void, ms: number, ...args: any[]): any;
+
 // Like global.setTimeout, except the callback runs with captured context.
 export { setTimeoutWithContext as setTimeout };
 function setTimeoutWithContext(callback: () => any, delay: number) {

--- a/packages/context/src/context.ts
+++ b/packages/context/src/context.ts
@@ -2,7 +2,13 @@ import { Slot } from "./slot";
 export { Slot }
 export const { bind, noContext } = Slot;
 
-declare function setTimeout(callback: (...args: any[]) => void, ms: number, ...args: any[]): any;
+// Relying on the @types/node declaration of global.setTimeout can make
+// things tricky for dowstream projects (see PR #7).
+declare function setTimeout(
+  callback: (...args: any[]) => any,
+  ms?: number,
+  ...args: any[]
+): any;
 
 // Like global.setTimeout, except the callback runs with captured context.
 export { setTimeoutWithContext as setTimeout };


### PR DESCRIPTION
It looks like the generated `context.d.ts` uses the `setTimeout` function from `@types/node`, which pulls all of the node types into the global namespace (or errors if `types/@node` isn't included in the project, see #4.)

This causes chaos for anyone using this library in a non-node Typescript project, which is likely a lot of people, since `@apollo/client` depends on `@wry/context`.

As far as I know there's no good way to handle this downstream, so I've included a kind of sucky but hopefully harmless workaround to keep this from pulling the node universe into the global scope.

Here are the differences in the generated `context.d.ts`:

```diff
-/// <reference types="node" />
import { Slot } from "./slot";
export { Slot };
export declare const bind: <TArgs extends any[], TResult>(callback: (...args: TArgs) => TResult) => (...args: TArgs) => TResult, noContext: <TResult, TArgs extends any[], TThis = any>(callback: (this: TThis, ...args: TArgs) => TResult, args?: TArgs | undefined, thisArg?: TThis | undefined) => TResult;
export { setTimeoutWithContext as setTimeout };
-declare function setTimeoutWithContext(callback: () => any, delay: number): NodeJS.Timeout;
+declare function setTimeoutWithContext(callback: () => any, delay: number): any;
export declare function asyncFromGen<TArgs extends any[]>(genFn: (...args: TArgs) => any): (...args: TArgs) => Promise<any>;
export declare function wrapYieldingFiberMethods<F extends Function>(Fiber: F): F;
```