### PR TITLE
Equate non-native functions that have the same code.

### DIFF
--- a/packages/equality/src/tests.ts
+++ b/packages/equality/src/tests.ts
@@ -206,12 +206,32 @@ describe("equality", function () {
     );
   });
 
-  it("should not equate distinct functions", function () {
+  it("should equate non-native functions with the same code", function () {
     const fn = () => 1234;
     assertEqual(fn, fn);
+    assertEqual(fn, () => 1234);
+
+    // These functions are behaviorally the same, but there's no way to
+    // decide that question statically.
     assertNotEqual(
-      fn,
-      () => 1234,
+      (a: number) => a + 1,
+      (b: number) => b + 1,
+    );
+
+    assertEqual(
+      { before: 123, fn() { return 4 }, after: 321 },
+      { after: 321, before: 123, fn() { return 4 } },
+    );
+
+    assertEqual(Object.assign, Object.assign);
+
+    // Since these slice methods are native functions, they happen to have
+    // exactly the same (censored) code, but we can test their equality by
+    // reference, since we can generally assume native functions are pure.
+    assertNotEqual(String.prototype.slice, Array.prototype.slice);
+    assertEqual(
+      Function.prototype.toString.call(String.prototype.slice),
+      Function.prototype.toString.call(Array.prototype.slice),
     );
   });
 });


### PR DESCRIPTION
Previously, function objects were regarded as equal by `@wry/equality` only if they were `===` to each other. This policy was overly restrictive in many common situations, such as when comparing functions that are repeatedly passed as fresh function expressions within objects that are otherwise deeply equal.

Thanks to this PR, the `@wry/equality` package now considers non-native functions equal if they are `===` (as before) _or_ if they have the same code according to `Function.prototype.toString`. For native functions, we must check `===` because their code is censored, e.g. `Object.assign.toString() === "function assign() { [native code] }"`.

Note that this behavior is not entirely sound, since `!==` function objects with the same code can behave differently depending on their closure scope. However, any function can behave differently depending on the values of its input arguments (including `this`) and its calling context (including its closure scope), even though the function object is obviously `===` to itself; and it is entirely possible for functions that are not `===` to behave exactly the same under all conceivable circumstances.

Because none of these factors are statically decidable in JavaScript (or any Turing-complete programming language, probably?), JS function equality is simply not well-defined. This ambiguity allows us to consider the best possible heuristic among various imperfect options, and equating non-native functions that have the same code has enormous practical benefits (see https://github.com/apollographql/apollo-client/pull/6588, for example).

I considered making this behavior configurable, until I realized that strict `===` equality was never an absolute guarantee of behavioral equivalence, anyway. Ambiguities can be liberating!