### PR TITLE
Consider undefined properties equivalent to missing properties.

### DIFF
--- a/packages/equality/src/equality.ts
+++ b/packages/equality/src/equality.ts
@@ -43,8 +43,8 @@ function check(a: any, b: any): boolean {
     case '[object Object]': {
       if (previouslyCompared(a, b)) return true;
 
-      const aKeys = Object.keys(a);
-      const bKeys = Object.keys(b);
+      const aKeys = definedKeys(a);
+      const bKeys = definedKeys(b);
 
       // If `a` and `b` have a different number of enumerable keys, they
       // must be different.
@@ -149,6 +149,18 @@ function check(a: any, b: any): boolean {
 
   // Otherwise the values are not equal.
   return false;
+}
+
+function definedKeys<TObject extends object>(obj: TObject) {
+  // Remember that the second argument to Array.prototype.filter will be
+  // used as `this` within the callback function.
+  return Object.keys(obj).filter(isDefinedKey, obj);
+}
+function isDefinedKey<TObject extends object>(
+  this: TObject,
+  key: keyof TObject,
+) {
+  return this[key] !== void 0;
 }
 
 const nativeCodeSuffix = "{ [native code] }";

--- a/packages/equality/src/tests.ts
+++ b/packages/equality/src/tests.ts
@@ -63,11 +63,12 @@ describe("equality", function () {
       [1, /*hole*/, 3],
     );
 
-    assertNotEqual(
+    assertEqual(
       [1, /*hole*/, 3],
       [1, void 0, 3],
     );
 
+    // Not equal because the arrays are a different length.
     assertNotEqual(
       [1, 2, /*hole*/,],
       [1, 2],
@@ -100,6 +101,23 @@ describe("equality", function () {
 
     b.foo = 42;
     assertNotEqual(a, b);
+  });
+
+  it("should consider undefined and missing object properties equivalent", function () {
+    assertEqual({
+      a: 1,
+      b: void 0,
+      c: 3,
+    }, {
+      a: 1,
+      c: 3,
+    });
+
+    assertEqual({
+      a: void 0,
+      b: void 0,
+      c: void 0,
+    }, {});
   });
 
   it("should work for Error objects", function () {


### PR DESCRIPTION
Previously, an object `a` with a key `k` whose value is undefined (that is, `a[k] === void 0`) would not be considered deeply equal to another object `b` that is missing that key, but is otherwise deeply equal to the first object, though `a[k] === b[k]`.

This commit makes these two different kinds of undefined-ness equivalent, by efficiently ignoring undefined-valued keys when comparing objects. This allows more objects than before to be considered equivalent, but the `equal(a, b)` function still obeys the rules of equivalence relations: reflexivity, symmetry, and transitivity.

This change is similar in spirit to the way we relaxed the strict `===` requirement for function objects in #12: more functions can be considered equivalent now, but the newly equivalent functions still obey the rules of equality, and thus the change is logically valid, a decision we are free to make but not forced to make.

The additional leniency will be useful in situations where (for example) multiple `options` objects are combined by application code and then passed to an API, perhaps using `...spread` syntax or `Object.assign`, and the API needs to decide if the new `options` are different from previous `options`. This change allows the application code to avoid worrying about the difference between undefined and missing object properties, a discipline that can unnecessarily complicate the way the options need to be combined.

Since the `@wry/equality` package has not yet reached 1.0.0, this change will be a minor version bump (0.3.0). Extrapolating from the success of #12, I do not anticipate this change will cause problems in practice, but we could (in principle, in the future) consider allowing the `equal` function to take options that configure how it behaves. If you're reading this because this PR caused you unexpected problems, please let me know below!