### PR TITLE
Fix equality check for async functions

### DIFF
--- a/packages/equality/src/equality.ts
+++ b/packages/equality/src/equality.ts
@@ -115,6 +115,8 @@ function check(a: any, b: any): boolean {
     }
 
     case '[object AsyncFunction]':
+    case '[object GeneratorFunction]':
+    case '[object AsyncGeneratorFunction]':
     case '[object Function]': {
       const aCode = fnToStr.call(a);
       if (aCode !== fnToStr.call(b)) {

--- a/packages/equality/src/equality.ts
+++ b/packages/equality/src/equality.ts
@@ -114,6 +114,7 @@ function check(a: any, b: any): boolean {
       return true;
     }
 
+    case '[object AsyncFunction]':
     case '[object Function]': {
       const aCode = fnToStr.call(a);
       if (aCode !== fnToStr.call(b)) {

--- a/packages/equality/src/tests.ts
+++ b/packages/equality/src/tests.ts
@@ -260,4 +260,58 @@ describe("equality", function () {
       Function.prototype.toString.call(Array.prototype.slice),
     );
   });
+
+  it("should equate async functions with the same code", function () {
+    const fn = async () => 1234;
+    assertEqual(fn, fn);
+    assertEqual(fn, async () => 1234);
+
+    // These functions are behaviorally the same, but there's no way to
+    // decide that question statically.
+    assertNotEqual(
+      async (a: number) => a + 1,
+      async (b: number) => b + 1,
+    );
+
+    assertEqual(
+      { before: 123, async fn() { return 4 }, after: 321 },
+      { after: 321, before: 123, async fn() { return 4 } },
+    );
+  });
+
+  it("should equate generator functions with the same code", function () {
+    const fn = function *() { return yield 1234 };
+    assertEqual(fn, fn);
+    assertEqual(fn, function *() { return yield 1234 });
+
+    // These functions are behaviorally the same, but there's no way to
+    // decide that question statically.
+    assertNotEqual(
+      function *(a: number) { return yield a + 1 },
+      function *(b: number) { return yield b + 1 },
+    );
+
+    assertEqual(
+      { before: 123, *fn() { return 4 }, after: 321 },
+      { after: 321, before: 123, *fn() { return 4 } },
+    );
+  });
+
+  it("should equate async generator functions with the same code", function () {
+    const fn = async function *() { return await (yield 1234) };
+    assertEqual(fn, fn);
+    assertEqual(fn, async function *() { return await (yield 1234) });
+
+    // These functions are behaviorally the same, but there's no way to
+    // decide that question statically.
+    assertNotEqual(
+      async function *(a: number) { return yield a + 1 },
+      async function *(b: number) { return yield b + 1 },
+    );
+
+    assertEqual(
+      { before: 123, async *fn() { return 4 }, after: 321 },
+      { after: 321, before: 123, async *fn() { return 4 } },
+    );
+  });
 });

--- a/packages/equality/tsconfig.json
+++ b/packages/equality/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "target": "esnext",
     "rootDir": "./src",
     "outDir": "./lib"
   }


### PR DESCRIPTION
toString.call(async () => {}) returns '[object AsyncFunction]'
Therefore, check() currently returns 'false' for any async functions
