### PR TITLE
Avoid shipping @wry/equality with "target": "esnext".

### DIFF
--- a/packages/equality/package.json
+++ b/packages/equality/package.json
@@ -21,7 +21,7 @@
     "tsc": "../../node_modules/.bin/tsc",
     "rollup": "../../node_modules/.bin/rollup -c",
     "build": "npm run clean && npm run tsc && npm run rollup",
-    "mocha": "../../scripts/test.sh lib/tests.js",
+    "mocha": "../../scripts/test.sh lib/tests.cjs.js",
     "prepublish": "npm run build",
     "test": "npm run build && npm run mocha"
   },

--- a/packages/equality/rollup.config.js
+++ b/packages/equality/rollup.config.js
@@ -4,6 +4,7 @@ import typescript from 'typescript';
 const globals = {
   __proto__: null,
   tslib: "tslib",
+  assert: "assert",
 };
 
 function external(id) {
@@ -37,4 +38,21 @@ export default [{
     name: "equality",
     globals,
   },
+}, {
+  input: "src/tests.ts",
+  external,
+  output: {
+    file: "lib/tests.cjs.js",
+    format: "cjs",
+    exports: "named",
+    sourcemap: true,
+    name: "equality-tests",
+    globals,
+  },
+  plugins: [
+    typescriptPlugin({
+      typescript,
+      tsconfig: "./tsconfig.test.json",
+    }),
+  ],
 }];

--- a/packages/equality/tsconfig.json
+++ b/packages/equality/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "target": "esnext",
     "rootDir": "./src",
     "outDir": "./lib"
   }

--- a/packages/equality/tsconfig.test.json
+++ b/packages/equality/tsconfig.test.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.rollup.json",
+  "compilerOptions": {
+    "target": "esnext",
+  },
+}


### PR DESCRIPTION
Should fix #99, while still running `@wry/equality` tests with native `async`/generator syntax, as needed by #95.