### PR TITLE
Update tslib dependencies to version 2.1.0.

### DIFF
--- a/packages/context/package-lock.json
+++ b/packages/context/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
+      "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A=="
     }
   }
 }

--- a/packages/context/package.json
+++ b/packages/context/package.json
@@ -26,7 +26,7 @@
     "test": "npm run build && npm run mocha"
   },
   "dependencies": {
-    "tslib": "^1.14.1"
+    "tslib": "^2.1.0"
   },
   "engines": {
     "node": ">=8"

--- a/packages/equality/package-lock.json
+++ b/packages/equality/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
+      "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A=="
     }
   }
 }

--- a/packages/equality/package.json
+++ b/packages/equality/package.json
@@ -26,7 +26,7 @@
     "test": "npm run build && npm run mocha"
   },
   "dependencies": {
-    "tslib": "^1.14.1"
+    "tslib": "^2.1.0"
   },
   "engines": {
     "node": ">=8"

--- a/packages/record/package-lock.json
+++ b/packages/record/package-lock.json
@@ -8,13 +8,13 @@
       "version": "file:../tuple",
       "requires": {
         "@wry/trie": "file:../trie",
-        "tslib": "^1.14.1"
+        "tslib": "^2.1.0"
       },
       "dependencies": {
         "@wry/trie": {
           "version": "file:../trie",
           "requires": {
-            "tslib": "^1.14.1"
+            "tslib": "^2.1.0"
           },
           "dependencies": {
             "tslib": {
@@ -32,9 +32,9 @@
       }
     },
     "tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
+      "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A=="
     }
   }
 }

--- a/packages/record/package.json
+++ b/packages/record/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "@wry/tuple": "file:../tuple",
-    "tslib": "^1.14.1"
+    "tslib": "^2.1.0"
   },
   "engines": {
     "node": ">=8"

--- a/packages/task/package-lock.json
+++ b/packages/task/package-lock.json
@@ -7,7 +7,7 @@
     "@wry/context": {
       "version": "file:../context",
       "requires": {
-        "tslib": "^1.14.1"
+        "tslib": "^2.1.0"
       },
       "dependencies": {
         "@types/node": {
@@ -23,9 +23,9 @@
       }
     },
     "tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
+      "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A=="
     }
   }
 }

--- a/packages/task/package.json
+++ b/packages/task/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "@wry/context": "file:../context",
-    "tslib": "^1.14.1"
+    "tslib": "^2.1.0"
   },
   "engines": {
     "node": ">=8"

--- a/packages/template/package-lock.json
+++ b/packages/template/package-lock.json
@@ -4,9 +4,9 @@
   "lockfileVersion": 1,
   "dependencies": {
     "tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
+      "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A=="
     }
   }
 }

--- a/packages/template/package.json
+++ b/packages/template/package.json
@@ -26,7 +26,7 @@
     "test": "npm run build && npm run mocha"
   },
   "dependencies": {
-    "tslib": "^1.14.1"
+    "tslib": "^2.1.0"
   },
   "engines": {
     "node": ">=8"

--- a/packages/trie/package-lock.json
+++ b/packages/trie/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
+      "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A=="
     }
   }
 }

--- a/packages/trie/package.json
+++ b/packages/trie/package.json
@@ -32,7 +32,7 @@
     "test": "npm run build && npm run mocha"
   },
   "dependencies": {
-    "tslib": "^1.14.1"
+    "tslib": "^2.1.0"
   },
   "engines": {
     "node": ">=8"

--- a/packages/tuple/package-lock.json
+++ b/packages/tuple/package-lock.json
@@ -7,7 +7,7 @@
     "@wry/trie": {
       "version": "file:../trie",
       "requires": {
-        "tslib": "^1.14.1"
+        "tslib": "^2.1.0"
       },
       "dependencies": {
         "tslib": {
@@ -18,9 +18,9 @@
       }
     },
     "tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
+      "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A=="
     }
   }
 }

--- a/packages/tuple/package.json
+++ b/packages/tuple/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "@wry/trie": "file:../trie",
-    "tslib": "^1.14.1"
+    "tslib": "^2.1.0"
   },
   "engines": {
     "node": ">=8"


### PR DESCRIPTION
TypeScript has started to complain about `tslib@1.x` dependencies, so I think it's time to get up-to-date. This will be a minor version bump for all packages in this repository.