### PR TITLE
Create `peek` and `peekArray` functions on `Trie` to lookup values without creating them

### DIFF
--- a/packages/trie/src/tests.ts
+++ b/packages/trie/src/tests.ts
@@ -87,4 +87,26 @@ describe("Trie", function () {
     // Verify that all Data objects are distinct.
     assert.strictEqual(new Set(datas).size, datas.length);
   });
+
+  it("can peek at values", function () {
+    const trie = new Trie(true, (args) => args);
+
+    const obj = {};
+    assert.strictEqual(trie.peek(1, 2, 'x'), undefined);
+    assert.strictEqual(trie.peek(1, 2, obj), undefined);
+    assert.strictEqual(trie.peekArray([1, 2, 'x']), undefined);
+    assert.strictEqual(trie.peekArray([1, 2, obj]), undefined);
+    // peek/peekArray should not create anything on its own
+    assert.strictEqual(trie['weak'], undefined);
+    assert.strictEqual(trie['strong'], undefined);
+    assert.strictEqual(trie['data'], undefined);
+
+    const data1 = trie.lookup(1, 2, 'x');
+    const data2 = trie.lookup(1, 2, obj);
+
+    assert.strictEqual(trie.peek(1, 2, 'x'), data1);
+    assert.strictEqual(trie.peek(1, 2, obj), data2);
+    assert.strictEqual(trie.peekArray([1, 2, 'x']), data1);
+    assert.strictEqual(trie.peekArray([1, 2, obj]), data2);
+  });
 });

--- a/packages/trie/src/trie.ts
+++ b/packages/trie/src/trie.ts
@@ -32,6 +32,16 @@ export class Trie<Data> {
     return node.data || (node.data = this.makeData(slice.call(array)));
   }
 
+  public peek<T extends any[]>(...array: T): Data | undefined {
+    return this.peekArray(array);
+  }
+
+  public peekArray<T extends IArguments | any[]>(array: T): Data | undefined {
+    let node: Trie<Data> | undefined = this;
+    forEach.call(array, (key) => (node = node && node.peekChildTrie(key)));
+    return node && node.data;
+  }
+
   private getChildTrie(key: any) {
     const map = this.weakness && isObjRef(key)
       ? this.weak || (this.weak = new WeakMap<any, Trie<Data>>())
@@ -39,6 +49,12 @@ export class Trie<Data> {
     let child = map.get(key);
     if (!child) map.set(key, child = new Trie<Data>(this.weakness, this.makeData));
     return child;
+  }
+
+  private peekChildTrie(key: any) {
+    const map = this.weakness && isObjRef(key) ? this.weak : this.strong;
+
+    return map && map.get(key);
   }
 }
 


### PR DESCRIPTION
For your consideration:

This PR adds `peek` and `peekArray` functions (mirroring `lookup` and `lookupArray`) that allow you to peek at data in the trie without creating intermediate `Trie` nodes, nor running the `makeData` function at the leaf node. This allows you to determine the presence or absence of a value at a leaf, without resorting to storing your own flags from the value returned by `makeData`.

---
As a practical example, I think `Trie` could be a great way to implement https://github.com/apollographql/apollo-client/issues/10767. We will allow users to pass us field paths in the link configuration, which we could then store in the `Trie`.

By using `peek` instead of `lookup`, we could then use the presence of a value at the given path to determine if a path has been configured or not. This also gives us the benefit that we don't need to store all the extra intermediate `Trie` nodes or `data` values for all paths passed through `lookup`. `Trie` will only store the data from the configured paths.

On top of this, I find this behavior with `peak` to be a bit more intuitive if the `Trie` is meant to store flags as values.

Here is a general idea how I see the usage in `StripTypenameLink`

```ts
// StripTypenameLink.ts

// All values stored in the trie are `true` to indicate they exist
const trie = new Trie<true>(true, () => true);

// store each path in the trie
// where fieldPaths is an array of arrays
fieldPaths.forEach(fieldPath => trie.lookupArray(fieldPath))

// if we get back `true`, we have configured a field path
// if `undefined`, this path is not configured 
const excluded = trie.peekArray(fieldPath);
```

## Alternatives

This can be accomplished with the existing `lookup`/`lookupArray` APIs, though I find the mechanics to be a bit more awkward since `makeData` is always run.

```ts
const trie = new Trie<true>(true, () => ({ excluded: false }));

fieldPaths.forEach(fieldPath => {
  const data = trie.lookupArray(fieldPath);

  data.excluded = true;
});

// later
const { excluded } = fieldPaths.lookupArray(fieldPath);
```

---

I'd love to hear if you think this is a valuable addition, or if this is just noise. Not having this API doesn't block anything, its more a convenience if you want to rely on the presence or absence of a stored value to mean something.
