### PR TITLE
Work around React Native / Metro refusing to load `.cjs` modules

### DIFF
--- a/shared/rollup.config.js
+++ b/shared/rollup.config.js
@@ -1,3 +1,5 @@
+import { readFile, writeFile } from "fs/promises";
+
 export const globals = {
   __proto__: null,
   tslib: "tslib",
@@ -22,6 +24,17 @@ export function build(input, output, format) {
       sourcemap: true,
       globals
     },
+    ...(output.endsWith(".cjs") ? { plugins: [
+      { // Inspired by https://github.com/apollographql/apollo-client/pull/9716,
+        // this workaround ensures compatibility with versions of React Native
+        // that refuse to load .cjs modules as CommonJS (to be fixed in v0.72):
+        name: "copy *.cjs to *.cjs.native.js",
+        async writeBundle({ file }) {
+          const buffer = await readFile(file);
+          await writeFile(file + ".native.js", buffer);
+        },
+      },
+    ]} : null),
   };
 }
 


### PR DESCRIPTION
Inspired by https://github.com/apollographql/apollo-client/pull/9716

Should resolve issue #483, not only for `@wry/equality` but also for the other `@wry/*` packages.