### PR TITLE
WeakCache: delayed finalization of nodes

### DIFF
--- a/shared/test.sh
+++ b/shared/test.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-node "$(dirname $0)/../node_modules/.bin/mocha" \
+node --expose-gc "$(dirname $0)/../node_modules/.bin/mocha" \
      --reporter spec \
      --full-trace \
      --require source-map-support/register \


### PR DESCRIPTION
This would delay the `new WeakRef` and `this.registry.register` calls into a later microtask (that is further chunked into multiple batches if necessary).

As you can see from the test output, the basic "adding items to the cache" is very fast, but both `new WeakRef` and `registry.register` take significantly longer.

This is from a local run with 100000 nodes (which will probably take even longer in CI here).

```
filling up cache: 403.389ms
finalizing a chunk: 8.936ms
finalizing a chunk: 14.83ms
finalizing a chunk: 8.447ms
finalizing a chunk: 16.229ms
finalizing a chunk: 15.989ms
finalizing a chunk: 11.666ms
finalizing a chunk: 21.831ms
[...snip...]
finalizing a chunk: 11.245ms
finalizing a chunk: 16.684ms
finalizing a chunk: 58.023ms
finalizing a chunk: 30.567ms
finalizing a chunk: 27.232ms
finalizing a chunk: 63.833ms
finalizing a chunk: 26.154ms
finalizing a chunk: 17.152ms
finalizing a chunk: 50.656ms
finalizing a chunk: 118.573ms
waiting for finalization: 1.822s
```