### PR TITLE
set `sideEffects: false` from `@wry/caches`

### DIFF
--- a/packages/caches/package.json
+++ b/packages/caches/package.json
@@ -1,10 +1,11 @@
 {
   "name": "@wry/caches",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "author": "Ben Newman <ben@eloper.dev>",
   "description": "Various cache implementations",
   "license": "MIT",
   "type": "module",
+  "sideEffects": false,
   "main": "lib/bundle.cjs",
   "module": "lib/index.js",
   "types": "lib/index.d.ts",


### PR DESCRIPTION
I just noticed that not all bundlers seem to split the `.cjs` output, even though both exports are independent from each other, so this should hopefully help.